### PR TITLE
Add a new preset for Klever to deal with BusyBox

### DIFF
--- a/clade/extensions/presets/presets.json
+++ b/clade/extensions/presets/presets.json
@@ -153,5 +153,15 @@
             "Macros",
             "CrossRef"
         ]
+    },
+    "klever_busybox_linux": {
+        "extends": "busybox_linux",
+        "extensions": [
+            "Callgraph",
+            "Variables",
+            "Typedefs",
+            "Macros",
+            "CrossRef"
+        ]
     }
 }


### PR DESCRIPTION
Add a new preset option to collect build bases for the BusyBox project and further their use in Klever.