### PR TITLE
Specify more options describing relation to host environment

### DIFF
--- a/clade/extensions/opts.py
+++ b/clade/extensions/opts.py
@@ -510,7 +510,9 @@ gcc_optimization_opts = [
 ]
 
 cif_supported_opts = (
-    ["-D", "-U", "-nostdinc", "-fshort-wchar", "-std", "--std", "-c"]
+    ["-D", "-U", "-fshort-wchar", "-std", "--std", "-c", ]
+    # Relation to a host environment such as the standard library. This is especially important for OS kernels.
+    + ["-nostdinc", "-fno-builtin", "-fno-hosted", "-ffreestanding"]
     + ["-mbig-endian", "-mlittle-endian", "-mabi"]  # arm
     + ["{}$".format(opt) for opt in gcc_optimization_opts]
     + include_opts


### PR DESCRIPTION
Without these options you can get errors like:

```
/usr/local/arm-unknown-eabi-cif/lib/gcc/arm-unknown-eabi/7.5.0/include/stdint.h:9:16: fatal error: stdint.h: No such file or directory
 # include_next <stdint.h>
                ^~~~~~~~~~
compilation terminated.
Aspectator failed at '2' stage.
```