### PR TITLE
Do not filter out -Werror-implicit-function-declaration

### DIFF
--- a/clade/extensions/opts.py
+++ b/clade/extensions/opts.py
@@ -518,7 +518,7 @@ cif_supported_opts = (
     # Machine-dependent options.
     + ["-mbig-endian", "-mlittle-endian", "-mabi"]
     # Options to enable different kinds of errors. They can help to make the source code better.
-    + ["-Werror-implicit-function-declaration"]
+    + ["-Werror-implicit-function-declaration", "-Werror=implicit-function-declaration"]
     + ["{}$".format(opt) for opt in gcc_optimization_opts]
     + include_opts
 )

--- a/clade/extensions/opts.py
+++ b/clade/extensions/opts.py
@@ -517,6 +517,8 @@ cif_supported_opts = (
     + ["-fshort-wchar", "-fno-short-wchar", "-fshort-enums", "-fno-short-enums"]
     # Machine-dependent options.
     + ["-mbig-endian", "-mlittle-endian", "-mabi"]
+    # Options to enable different kinds of errors. They can help to make the source code better.
+    + ["-Werror-implicit-function-declaration"]
     + ["{}$".format(opt) for opt in gcc_optimization_opts]
     + include_opts
 )


### PR DESCRIPTION
This option is used at compilation of the Linux kernel and it is great to use it for compilation of other related stuff to improve it.